### PR TITLE
Robustness logging patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ install:
 	@cp borg_exporter.sh /usr/local/bin/ \
 	&& chmod +x /usr/local/bin/borg_exporter.sh \
 	&& cp -n borg_exporter.rc /etc/borg_exporter.rc \
+	&& chmod 600 /etc/borg_exporter.rc \
 	&& cp prometheus-borg-exporter.timer /etc/systemd/system/ \
 	&& cp prometheus-borg-exporter.service /etc/systemd/system/ \
 	&& echo -n "Edit the config file /etc/borg_exporter.rc and press [ENTER] when finished "; read _ \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For convenience, you can install this exporter with the command line
 ### Manually
 Copy `borg_exporter.sh` to `/usr/local/bin`.
 
-Copy `borg.env` to `/etc/borg` and replace your repokey and repository in it.
+Copy `borg_exporter.rc` to `/etc/borg_exporter.rc` and replace your repokey and repository in it.
 
 Copy the systemd unit to `/etc/systemd/system` and run 
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Alternative: Use `ExecStartPost` in your borg backupt timer itself to write our 
  * By default, borg_exporter will be quiet if no errors occur. You can use the -v or --verbose option get a progress log as the program runs. If using systemd, you can use journalctl to view the log.
  * Using the -x or --no-extract option will prevent the exporter from running the ```borg extract``` command. This is useful if running against a remote or very large repository, as the extract command can take a long time to run.
  * Use -c or --config to specify a different configuration file. The default is /etc/borg_exporter.rc file.
+ * Use -u or --user and -g or --group to specify the user and group of the file created by the exporter.
 
 ## Configure your node exporter
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ systemctl start prometheus-borg-exporter.timer
 
 Alternative: Use `ExecStartPost` in your borg backupt timer itself to write our the metrics.
 
+## Configuration options
+ * By default, borg_exporter will be quiet if no errors occur. You can use the -v or --verbose option get a progress log as the program runs. If using systemd, you can use journalctl to view the log.
+ * Using the -x or --no-extract option will prevent the exporter from running the ```borg extract``` command. This is useful if running against a remote or very large repository, as the extract command can take a long time to run.
+ * Use -c or --config to specify a different configuration file. The default is /etc/borg_exporter.rc file.
+
 ## Configure your node exporter
 
 You must start the node exporter service with the following parameter: `--collector.textfile.directory=/var/lib/node_exporter/textfile_collector`

--- a/borg_exporter.rc
+++ b/borg_exporter.rc
@@ -1,3 +1,3 @@
-BORG_PASSPHRASE=<your-passphrase>
-REPOSITORY=<your-repository>
-COLLECTOR_DIR=</var/lib/node_exporter/textfile_collector>
+BORG_PASSPHRASE=your-passphrase
+REPOSITORY=your-repository
+COLLECTOR_DIR=/var/lib/node_exporter/textfile_collector

--- a/borg_exporter.sh
+++ b/borg_exporter.sh
@@ -2,40 +2,37 @@
 
 set -eu
 
-source /etc/borg_exporter.rc
+CONFIG_VERBOSE=0
+CONFIG_EXTRACT=1
+CONFIG_BORG_EXPORTER_RC=/etc/borg_exporter.rc
 
-TEXTFILE_COLLECTOR_DIR=/var/lib/node_exporter/textfile_collector
-PROM_FILE=$TEXTFILE_COLLECTOR_DIR/bork.prom
+cleanup() {
+    [ -f "$TMP_FILE" ] && rm -f "$TMP_FILE"
+}
 
-TMP_FILE=$PROM_FILE.$$
-[ -e $TMP_FILE ] && rm -f $TMP_FILE
+trap cleanup EXIT
 
-HOSTNAME=$(hostname)
-ARCHIVES=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg list "$REPOSITORY")
-COUNTER=0
+function log {
+	echo "$@"
+}
 
-[ -e "$TEXTFILE_COLLECTOR_DIR" ] || mkdir -p "$TEXTFILE_COLLECTOR_DIR"
+function verbose {
+	[ "$CONFIG_VERBOSE" == "1" ] && log "$@"
+}
 
-COUNTER=$(echo "$ARCHIVES" | wc -l)
-LAST_ARCHIVE=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg list --last 1 "$REPOSITORY" | sort -nr | head -n 1)
-LAST_ARCHIVE_NAME=$(echo $LAST_ARCHIVE | awk '{print $1}')
-LAST_ARCHIVE_DATE=$(echo $LAST_ARCHIVE | awk '{print $3" "$4}')
-LAST_ARCHIVE_TIMESTAMP=$(date -d "$LAST_ARCHIVE_DATE" +"%s")
-CURRENT_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
-NB_HOUR_FROM_LAST_BCK=$(dateutils.ddiff "$LAST_ARCHIVE_DATE" "$CURRENT_DATE" -f '%H')
+function error {
+  log "Error: $@" >&2
+  exit 1
+}
 
-BORG_EXTRACT_EXIT_CODE=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg extract --dry-run "$REPOSITORY::$LAST_ARCHIVE_NAME" > /dev/null 2>&1; echo $?)
-BORG_INFO=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg info "$REPOSITORY::$LAST_ARCHIVE_NAME")
-
-{
-  echo "borg_last_archive_timestamp{host=\"${HOSTNAME}\"} $LAST_ARCHIVE_TIMESTAMP"
-  echo "borg_extract_exit_code{host=\"${HOSTNAME}\"} $BORG_EXTRACT_EXIT_CODE"
-  echo "borg_hours_from_last_archive{host=\"${HOSTNAME}\"} $NB_HOUR_FROM_LAST_BCK"
-  echo "borg_archives_count{host=\"${HOSTNAME}\"} $COUNTER"
-  echo "borg_files_count{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Number of files" | awk '{print $4}')"
-  echo "borg_chunks_unique{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chunk index" | awk '{print $3}')"
-  echo "borg_chunks_total{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chunk index" | awk '{print $4}')"
-} >> $TMP_FILE
+function usage {
+    echo "Usage: $0 [-v|--verbose] [-h|--help]"
+    echo "  -v, --verbose    Enable verbose mode"
+    echo "  -h, --help       Display this help message"
+    echo "  -x, --no-extract Disable archive extraction, recommended for large/remote repositories"
+    echo "  -c, --config     Specify a configuration file (default: /etc/borg_exporter.rc)"
+    exit 0
+}
 
 function calc_bytes {
   NUM=$1
@@ -57,6 +54,94 @@ function calc_bytes {
   esac
 }
 
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -v|--verbose) CONFIG_VERBOSE=1 ;;
+        -h|--help) usage ;;
+        -x|--no-extract) CONFIG_EXTRACT=0 ;;
+        -c|--config) CONFIG_BORG_EXPORTER_RC="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; usage ;;
+    esac
+    shift
+done
+
+if ! command -v borg > /dev/null 2>&1; then
+  error "Unable to find borg executable in PATH, is borg installed?"
+  exit 1
+fi
+
+if ! command -v dateutils.ddiff > /dev/null 2>&1; then
+  error "Unable to find dateutils.ddiff executable in PATH, are dateutils installed?"
+  exit 1
+fi
+
+[ -e $CONFIG_BORG_EXPORTER_RC ] || {
+  error "Configuration file $CONFIG_BORG_EXPORTER_RC not found"
+  exit 1
+}
+
+source $CONFIG_BORG_EXPORTER_RC
+
+[ -z "$BORG_PASSPHRASE" ] && {
+  error "BORG_PASSPHRASE is not set in $CONFIG_BORG_EXPORTER_RC"
+  exit 1
+}
+
+[ -z "$REPOSITORY" ] && {
+  error "REPOSITORY is not set in $CONFIG_BORG_EXPORTER_RC"
+  exit 1
+}
+
+[ -z "$COLLECTOR_DIR" ] && {
+  error "COLLECTOR_DIR not set in $CONFIG_BORG_EXPORTER_RC"
+  exit 1
+}
+
+PROM_FILE=$COLLECTOR_DIR/borg.prom
+TMP_FILE=$(mktemp)
+HOSTNAME=$(hostname)
+
+if [ -e "$COLLECTOR_DIR" ]; then
+  if [ ! -d "$COLLECTOR_DIR" ]; then
+    error "$COLLECTOR_DIR is not a directory, aborting"
+    exit 1
+  fi
+else
+  mkdir -p "$COLLECTOR_DIR"
+fi
+
+[ -f $TMP_FILE ] && rm -f $TMP_FILE
+
+verbose "PROM_FILE: $PROM_FILE"
+verbose "TMP_FILE: $TMP_FILE"
+verbose "HOSTNAME: $HOSTNAME"
+
+verbose "Retrieving repository list..."
+ARCHIVES=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg list "$REPOSITORY")
+COUNTER=0
+
+COUNTER=$(echo "$ARCHIVES" | wc -l)
+
+verbose "Retrieving last archive..."
+LAST_ARCHIVE=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg list --last 1 "$REPOSITORY" | sort -nr | head -n 1)
+LAST_ARCHIVE_NAME=$(echo $LAST_ARCHIVE | awk '{print $1}')
+LAST_ARCHIVE_DATE=$(echo $LAST_ARCHIVE | awk '{print $3" "$4}')
+LAST_ARCHIVE_TIMESTAMP=$(date -d "$LAST_ARCHIVE_DATE" +"%s")
+CURRENT_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
+NB_HOUR_FROM_LAST_BCK=$(dateutils.ddiff "$LAST_ARCHIVE_DATE" "$CURRENT_DATE" -f '%H')
+
+if [ "$CONFIG_EXTRACT" == "1" ]; then
+  verbose "Extracting archive..."
+  BORG_EXTRACT_EXIT_CODE=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg extract --dry-run "$REPOSITORY::$LAST_ARCHIVE_NAME" > /dev/null 2>&1; echo $?)
+else
+  verbose "Skipping archive extraction"
+  BORG_EXTRACT_EXIT_CODE=0
+fi
+
+verbose "Retrieving repository info..."
+BORG_INFO=$(BORG_PASSPHRASE="$BORG_PASSPHRASE" borg info "$REPOSITORY::$LAST_ARCHIVE_NAME")
+
+verbose "Calculating sizes..."
 # byte size
 LAST_SIZE=$(calc_bytes $(echo "$BORG_INFO" | grep "This archive" | awk '{print $3}') $(echo "$BORG_INFO" | grep "This archive" | awk '{print $4}'))
 LAST_SIZE_COMPRESSED=$(calc_bytes $(echo "$BORG_INFO" | grep "This archive" | awk '{print $5}') $(echo "$BORG_INFO" | grep "This archive" | awk '{print $6}'))
@@ -65,13 +150,21 @@ TOTAL_SIZE=$(calc_bytes $(echo "$BORG_INFO" | grep "All archives" | awk '{print 
 TOTAL_SIZE_COMPRESSED=$(calc_bytes $(echo "$BORG_INFO" | grep "All archives" | awk '{print $5}') $(echo "$BORG_INFO" | grep "All archives" | awk '{print $6}'))
 TOTAL_SIZE_DEDUP=$(calc_bytes $(echo "$BORG_INFO" | grep "All archives" | awk '{print $7}') $(echo "$BORG_INFO" | grep "All archives" | awk '{print $8}'))
 
+verbose "Writing data..."
 {
+  echo "borg_last_archive_timestamp{host=\"${HOSTNAME}\"} $LAST_ARCHIVE_TIMESTAMP"
+  echo "borg_extract_exit_code{host=\"${HOSTNAME}\"} $BORG_EXTRACT_EXIT_CODE"
+  echo "borg_hours_from_last_archive{host=\"${HOSTNAME}\"} $NB_HOUR_FROM_LAST_BCK"
+  echo "borg_archives_count{host=\"${HOSTNAME}\"} $COUNTER"
+  echo "borg_files_count{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Number of files" | awk '{print $4}')"
+  echo "borg_chunks_unique{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chunk index" | awk '{print $3}')"
+  echo "borg_chunks_total{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chunk index" | awk '{print $4}')"
   echo "borg_last_size{host=\"${HOSTNAME}\"} $LAST_SIZE"
   echo "borg_last_size_compressed{host=\"${HOSTNAME}\"} $LAST_SIZE_COMPRESSED"
   echo "borg_last_size_dedup{host=\"${HOSTNAME}\"} $LAST_SIZE_DEDUP"
   echo "borg_total_size{host=\"${HOSTNAME}\"} $TOTAL_SIZE"
   echo "borg_total_size_compressed{host=\"${HOSTNAME}\"} $TOTAL_SIZE_COMPRESSED"
   echo "borg_total_size_dedup{host=\"${HOSTNAME}\"} $TOTAL_SIZE_DEDUP"
-} >> $TMP_FILE
+} > $TMP_FILE
 
 mv -f $TMP_FILE $PROM_FILE

--- a/borg_exporter.sh
+++ b/borg_exporter.sh
@@ -7,7 +7,9 @@ CONFIG_EXTRACT=1
 CONFIG_BORG_EXPORTER_RC=/etc/borg_exporter.rc
 
 cleanup() {
-    [ -f "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    if [ -f "$TMP_FILE" ]; then
+      rm -f "$TMP_FILE"
+    fi
 }
 
 trap cleanup EXIT
@@ -166,3 +168,5 @@ verbose "Writing data..."
 } > $TMP_FILE
 
 mv -f $TMP_FILE $PROM_FILE
+
+exit 0

--- a/borg_exporter.sh
+++ b/borg_exporter.sh
@@ -110,8 +110,6 @@ else
   mkdir -p "$COLLECTOR_DIR"
 fi
 
-[ -f $TMP_FILE ] && rm -f $TMP_FILE
-
 verbose "PROM_FILE: $PROM_FILE"
 verbose "TMP_FILE: $TMP_FILE"
 verbose "HOSTNAME: $HOSTNAME"

--- a/borg_exporter.sh
+++ b/borg_exporter.sh
@@ -33,6 +33,8 @@ function usage {
     echo "  -h, --help       Display this help message"
     echo "  -x, --no-extract Disable archive extraction, recommended for large/remote repositories"
     echo "  -c, --config     Specify a configuration file (default: /etc/borg_exporter.rc)"
+    echo "  -u, --user       Specify a user to to set as owner of the node exporter file"
+    echo "  -g, --group      Specify a group to to set as owner of the node exporter file"
     exit 0
 }
 
@@ -62,6 +64,8 @@ while [[ "$#" -gt 0 ]]; do
         -h|--help) usage ;;
         -x|--no-extract) CONFIG_EXTRACT=0 ;;
         -c|--config) CONFIG_BORG_EXPORTER_RC="$2"; shift ;;
+        -u|--user) CONFIG_USER="$2"; shift ;;
+        -g|--group) CONFIG_GROUP="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
     esac
     shift
@@ -168,5 +172,13 @@ verbose "Writing data..."
 } > $TMP_FILE
 
 mv -f $TMP_FILE $PROM_FILE
+
+if [ -n "$CONFIG_USER" ]; then
+  chown $CONFIG_USER $PROM_FILE
+fi
+
+if [ -n "$CONFIG_GROUP" ]; then
+  chgrp $CONFIG_GROUP $PROM_FILE
+fi
 
 exit 0


### PR DESCRIPTION
I had a couple of use-cases not covered in this great script. I think these changes turned out nice.

- Added trap cleanup of TMP_FILE. This way, the tmp file is removed even if the program fails
- Changed location of TMP_FILE in order to not clutter node_exporter write dir
- Added Command line arg for verbose logging
- Added Command line arg for skipping the extract phase. For remote (large) repositories, this is quite handy
- Added sanity checks from user config
- Added checks for borg and dateutils binaries before starting execution
- Removed hardcoded values and/or added ability to override them
- Renmed bork.prom to borg.prom
- Added chmod 600 to the sensitive borg_exporter.rc on install
- Fixed typeo in README referring to borg.env
- Added command line documentation to README